### PR TITLE
Allow create_client() to load to local or production instances

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -32,8 +32,8 @@ def ingest(client, document):
 def create_client():
     load_dotenv()
 
-    host = 'localhost'
-    port = 9200
+    host = os.getenv('OPENSEARCH_HOST')
+    port = os.getenv('OPENSEARCH_PORT')
     password = os.getenv('OPENSEARCH_INITIAL_PASSWORD')
     auth = ('admin', password)
     ca_certs_path = certifi.where()


### PR DESCRIPTION
Insted of hard-coding the hostname and the port, create_client() now reads both parameters from a .env file. This allows the ingest script to work both locally and in production, based on the contents of the .env file.