### PR TITLE
Modify delete_client.py to delete data locally or in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This repo contains:
 
   ```
   OPENSEARCH_INITIAL_PASSWORD=<password>
+  OPENSEARCH_HOST=<hostname>
+  OPENSEARCH_PORT=<port>
   ```
 
 * Copy dockets from S3 (This step assumes you have the AWS CLI installed and configured).  In the root of this project run the following to download the data of two dockets.

--- a/delete_client.py
+++ b/delete_client.py
@@ -7,8 +7,8 @@ import certifi
 def create_client():
     load_dotenv()
 
-    host = 'localhost'
-    port = 9200
+    host = os.getenv('OPENSEARCH_HOST')
+    port = os.getenv('OPENSEARCH_PORT')
     password = os.getenv('OPENSEARCH_INITIAL_PASSWORD')
     auth = ('admin', password)
     ca_certs_path = certifi.where()


### PR DESCRIPTION
The OpenSearch hostname and port are now specified in a .env file, so data
can be delete locally or in production. Also includes a modification to the 
README.md with instructions for fields to add to the .env file.