### PR TITLE
Docker compose environment variable simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,9 @@ This repo contains:
   source .venv/bin/activate
   pip install -r requirements.txt
   ```
-
-* Set your password as an environment variable for the `docker-compose` file.
+ ### Environment Variables
 
   The `<password>` must have at least one upper, lower, number, and special characters and be at least 8 characters.
-
-  ```
-  export OPENSEARCH_INITIAL_ADMIN_PASSWORD=<password>
-  ```
 
   NOTE: including a `$` in the password as a special character leads to issues when running `docker compose` later on (the following text gets interpreted
   as a shell variable), so avoid using `$` in your password.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
     image: opensearchproject/opensearch:latest
     container_name: opensearch-node1
+    env_file: ".env"
     environment:
       - cluster.name=opensearch-cluster # Name the cluster
       - node.name=opensearch-node1 # Name the node that will run in this container
@@ -28,6 +29,7 @@ services:
   opensearch-node2:
     image: opensearchproject/opensearch:latest # This should be the same image used for opensearch-node1 to avoid issues
     container_name: opensearch-node2
+    env_file: ".env"
     environment:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2 # Nodes eligibile to serve as cluster manager
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD} # Sets the demo admin user password when using demo configuration (for OpenSearch 2.12 and later)
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_PASSWORD} # Sets the demo admin user password when using demo configuration (for OpenSearch 2.12 and later)
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)
@@ -37,7 +37,7 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_PASSWORD}
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
This PR simplifies the setup of OpenSearch.
The OpenSearch node docker containers now load the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` from the .env file instead of the environment.

**No changes to the .env file is required for this change**