### PR TITLE
Allow for interaction with a cloud instance of OpenSearch Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ And confirm that you can communicate with the server (#5 of the [quickstart](htt
   ```
   curl https://localhost:9200 -ku admin:<custom-admin-password>
   ```  
+
+If there is already data in the local OpenSearch instance, it takes time to load the data from the external volume. If you get an error related to `UNEXPECTED_EOF_WHILE_READING` when running a query, just wait and the issue will resolve itself.
   
 ### Shutdown OpenSearch
 
@@ -108,7 +110,7 @@ The `query.py` script will query OpenSearch to determine how many comments match
 
 ### Clean Up
 
-Data is stored in an external volume and will be retained if you stop the Docker containers.  Use the `delete_client.py` script to delete the data
+This is for deleting data from an OpenSearch instance. Locally and in production, data will remain stored unless you run `delete_client.py`. Use the `delete_client.py` script to delete the data
 
   ```
   python delete_client.py

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This repo contains:
   source .venv/bin/activate
   pip install -r requirements.txt
   ```
+  
+  
+## Local Deployment
 
 * Set your password as an environment variable for the `docker-compose` file.
 
@@ -34,13 +37,14 @@ This repo contains:
 
   ```
   OPENSEARCH_INITIAL_PASSWORD=<password>
-  OPENSEARCH_HOST=<hostname>
-  OPENSEARCH_PORT=<port>
+  OPENSEARCH_HOST=localhost
+  OPENSEARCH_PORT=9200
   S3_BUCKET_NAME=<bucket-name>
   ```
-  
-  
-## Start OpenSearch
+
+In the .env file, set the hostname to `localhost` and the port to `9200`.
+
+### Start OpenSearch
 
 Based on the [quickstart](https://opensearch.org/docs/latest/getting-started/quickstart/).  I ignored step 1, and it worked fine on my laptop.
 
@@ -62,33 +66,7 @@ And confirm that you can communicate with the server (#5 of the [quickstart](htt
   curl https://localhost:9200 -ku admin:<custom-admin-password>
   ```  
   
-## Ingest
-
-With the virtual environment active and OpenSearch running via Docker, run the ingest script:
-
-  ```
-  python ingest.py
-  ```
-  
-  This will produce one line of output per comment.  It takes a few minutes to complete.
-  
-## Query
-
-The `query.py` script will query OpenSearch to determine how many comments match "drug" in each docket.
-
-  ```
-  python query.py
-  ```
-
-## Clean Up
-
-Data is stored in an external volume and will be retained if you stop the Docker containers.  Use the `delete_client.py` script to delete the data
-
-  ```
-  python delete_client.py
-  ```
-  
-## Shutdown OpenSearch
+### Shutdown OpenSearch
 
 To stop OpenSearch, run
 
@@ -96,4 +74,42 @@ To stop OpenSearch, run
   docker compose down
   ```
   
+## Cloud Deployment
+
+* Create a `.env` file containing:
+
+  ```
+  OPENSEARCH_HOST=<hostname>
+  OPENSEARCH_PORT=443
+  S3_BUCKET_NAME=<bucket-name>
+  ```
+
+The hostname is the OpenSearch endpoint of the collection.
     
+## Perform Operations
+
+### Ingest
+
+With the virtual environment active, run the ingest script:
+
+  ```
+  python ingest.py
+  ```
+  
+This will produce one line of output per comment.  It takes a few minutes to complete.
+  
+### Query
+
+The `query.py` script will query OpenSearch to determine how many comments match "drug" in each docket.
+
+  ```
+  python query.py
+  ```
+
+### Clean Up
+
+Data is stored in an external volume and will be retained if you stop the Docker containers.  Use the `delete_client.py` script to delete the data
+
+  ```
+  python delete_client.py
+  ```

--- a/create_client.py
+++ b/create_client.py
@@ -1,0 +1,30 @@
+import os
+from dotenv import load_dotenv
+import certifi
+import boto3
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
+
+def create_client():
+    load_dotenv()
+
+    host = os.getenv('OPENSEARCH_HOST')
+    port = os.getenv('OPENSEARCH_PORT')
+    region = 'us-east-1'
+
+    service = 'aoss'
+    credentials = boto3.Session().get_credentials()
+    auth = AWSV4SignerAuth(credentials, region, service)
+
+
+    # Create the client with SSL/TLS enabled, but hostname verification disabled.
+    client = OpenSearch(
+        hosts=[{'host': host, 'port': port}],
+        http_compress = True, # enables gzip compression for request bodies
+        http_auth=auth,
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+        pool_maxsize=20,
+    )
+
+    return client

--- a/create_client.py
+++ b/create_client.py
@@ -11,6 +11,27 @@ def create_client():
     port = os.getenv('OPENSEARCH_PORT')
     region = 'us-east-1'
 
+    if host is None or port is None:
+        raise ValueError('Please set the environment variables OPENSEARCH_HOST and OPENSEARCH_PORT')
+    
+    if host == 'localhost':
+        auth = ('admin', os.getenv('OPENSEARCH_INITIAL_PASSWORD'))
+
+        ca_certs_path = certifi.where()
+        # Create the client with SSL/TLS enabled, but hostname verification disabled.
+        client = OpenSearch(
+            hosts = [{'host': host, 'port': port}],
+            http_compress = True, # enables gzip compression for request bodies
+            http_auth = auth,
+            use_ssl = True,
+            verify_certs = False,
+            ssl_assert_hostname = False,
+            ssl_show_warn = False,
+            ca_certs = ca_certs_path
+        )
+
+        return client
+    
     service = 'aoss'
     credentials = boto3.Session().get_credentials()
     auth = AWSV4SignerAuth(credentials, region, service)

--- a/delete_client.py
+++ b/delete_client.py
@@ -1,7 +1,8 @@
-from opensearchpy import OpenSearch
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 import os
 from dotenv import load_dotenv
 import certifi
+import boto3
 
 
 def create_client():
@@ -9,21 +10,22 @@ def create_client():
 
     host = os.getenv('OPENSEARCH_HOST')
     port = os.getenv('OPENSEARCH_PORT')
-    password = os.getenv('OPENSEARCH_INITIAL_PASSWORD')
-    auth = ('admin', password)
-    ca_certs_path = certifi.where()
+    region = 'us-east-1'
+
+    service = 'aoss'
+    credentials = boto3.Session().get_credentials()
+    auth = AWSV4SignerAuth(credentials, region, service)
 
 
     # Create the client with SSL/TLS enabled, but hostname verification disabled.
     client = OpenSearch(
-        hosts = [{'host': host, 'port': port}],
+        hosts=[{'host': host, 'port': port}],
         http_compress = True, # enables gzip compression for request bodies
-        http_auth = auth,
-        use_ssl = True,
-        verify_certs = False,
-        ssl_assert_hostname = False,
-        ssl_show_warn = False,
-        ca_certs = ca_certs_path
+        http_auth=auth,
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+        pool_maxsize=20,
     )
 
     return client

--- a/delete_client.py
+++ b/delete_client.py
@@ -1,34 +1,4 @@
-from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-import os
-from dotenv import load_dotenv
-import certifi
-import boto3
-
-
-def create_client():
-    load_dotenv()
-
-    host = os.getenv('OPENSEARCH_HOST')
-    port = os.getenv('OPENSEARCH_PORT')
-    region = 'us-east-1'
-
-    service = 'aoss'
-    credentials = boto3.Session().get_credentials()
-    auth = AWSV4SignerAuth(credentials, region, service)
-
-
-    # Create the client with SSL/TLS enabled, but hostname verification disabled.
-    client = OpenSearch(
-        hosts=[{'host': host, 'port': port}],
-        http_compress = True, # enables gzip compression for request bodies
-        http_auth=auth,
-        use_ssl=True,
-        verify_certs=True,
-        connection_class=RequestsHttpConnection,
-        pool_maxsize=20,
-    )
-
-    return client
+from create_client import create_client
 
 
 client = create_client()

--- a/ingest.py
+++ b/ingest.py
@@ -1,41 +1,12 @@
-
 import os
 import json
-from dotenv import load_dotenv
-import certifi
-from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 import boto3
+from create_client import create_client
 
 
 def ingest(client, document):
-    response = client.index(index = 'comments', body = document, refresh = True)
+    response = client.index(index = 'comments', body = document)
     print(response)
-
-
-def create_client():
-    load_dotenv()
-
-    host = os.getenv('OPENSEARCH_HOST')
-    port = os.getenv('OPENSEARCH_PORT')
-    region = 'us-east-1'
-
-    service = 'aoss'
-    credentials = boto3.Session().get_credentials()
-    auth = AWSV4SignerAuth(credentials, region, service)
-
-
-    # Create the client with SSL/TLS enabled, but hostname verification disabled.
-    client = OpenSearch(
-        hosts=[{'host': host, 'port': port}],
-        http_compress = True, # enables gzip compression for request bodies
-        http_auth=auth,
-        use_ssl=True,
-        verify_certs=True,
-        connection_class=RequestsHttpConnection,
-        pool_maxsize=20,
-    )
-
-    return client
 
 def ingest_comment(client, bucket, key):
     obj = bucket.Object(key)

--- a/ingest.py
+++ b/ingest.py
@@ -3,7 +3,7 @@ import os
 import json
 from dotenv import load_dotenv
 import certifi
-from opensearchpy import OpenSearch
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 import boto3
 
 
@@ -17,21 +17,22 @@ def create_client():
 
     host = os.getenv('OPENSEARCH_HOST')
     port = os.getenv('OPENSEARCH_PORT')
-    password = os.getenv('OPENSEARCH_INITIAL_PASSWORD')
-    auth = ('admin', password)
-    ca_certs_path = certifi.where()
+    region = 'us-east-1'
+
+    service = 'aoss'
+    credentials = boto3.Session().get_credentials()
+    auth = AWSV4SignerAuth(credentials, region, service)
 
 
     # Create the client with SSL/TLS enabled, but hostname verification disabled.
     client = OpenSearch(
-        hosts = [{'host': host, 'port': port}],
+        hosts=[{'host': host, 'port': port}],
         http_compress = True, # enables gzip compression for request bodies
-        http_auth = auth,
-        use_ssl = True,
-        verify_certs = False,
-        ssl_assert_hostname = False,
-        ssl_show_warn = False,
-        ca_certs = ca_certs_path
+        http_auth=auth,
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+        pool_maxsize=20,
     )
 
     return client

--- a/query.py
+++ b/query.py
@@ -1,31 +1,6 @@
-from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-import os
-from dotenv import load_dotenv
-import certifi
-import boto3
+from create_client import create_client
 
-load_dotenv()
-
-
-host = os.getenv('OPENSEARCH_HOST')
-port = os.getenv('OPENSEARCH_PORT')
-region = 'us-east-1'
-
-service = 'aoss'
-credentials = boto3.Session().get_credentials()
-auth = AWSV4SignerAuth(credentials, region, service)
-
-
-# Create the client with SSL/TLS enabled, but hostname verification disabled.
-client = OpenSearch(
-    hosts=[{'host': host, 'port': port}],
-    http_compress = True, # enables gzip compression for request bodies
-    http_auth=auth,
-    use_ssl=True,
-    verify_certs=True,
-    connection_class=RequestsHttpConnection,
-    pool_maxsize=20,
-)
+client = create_client()
 
 index_name = "comments"
 

--- a/query.py
+++ b/query.py
@@ -1,28 +1,32 @@
-from opensearchpy import OpenSearch
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 import os
 from dotenv import load_dotenv
 import certifi
+import boto3
 
 load_dotenv()
 
 
-host = 'localhost'
-port = 9200
-password = os.getenv('OPENSEARCH_INITIAL_PASSWORD')
-auth = ('admin', password)
-ca_certs_path = certifi.where()
+host = os.getenv('OPENSEARCH_HOST')
+port = os.getenv('OPENSEARCH_PORT')
+region = 'us-east-1'
+
+service = 'aoss'
+credentials = boto3.Session().get_credentials()
+auth = AWSV4SignerAuth(credentials, region, service)
+
 
 # Create the client with SSL/TLS enabled, but hostname verification disabled.
 client = OpenSearch(
-    hosts = [{'host': host, 'port': port}],
+    hosts=[{'host': host, 'port': port}],
     http_compress = True, # enables gzip compression for request bodies
-    http_auth = auth,
-    use_ssl = True,
-    verify_certs = False,
-    ssl_assert_hostname = False,
-    ssl_show_warn = False,
-    ca_certs = ca_certs_path
+    http_auth=auth,
+    use_ssl=True,
+    verify_certs=True,
+    connection_class=RequestsHttpConnection,
+    pool_maxsize=20,
 )
+
 index_name = "comments"
 
 query = {


### PR DESCRIPTION
Modifies ingest.py, query.py, and delete_client.py so that the user can use all three scripts to interact with an OpenSearch Serverless collection hosted on AWS. Provides documentation for how to do this in README.md.